### PR TITLE
Add support for coding standard

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,3 +9,4 @@ project_page 'https://github.com/rafaelfelix/puppet-phpqatools'
 
 ## Add dependencies, if any:
 dependency 'rafaelfc/pear', '>= 1.0.3'
+dependency 'puppetlabs/vcsrepo', '>= 0.1.2'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Dependencies
 - Ruby (tested against 1.8 version)
 - Rubygems
 - Puppet (>= 2.6)
+- vcsrepo (git/subversion/...) (if additional coding standard is need, https://github.com/puppetlabs/puppetlabs-vcsrepo)
 
 Tools
 -----
@@ -46,6 +47,24 @@ Inside of a puppet manifest file (let's call it init.pp):
 Then:
 
     $ puppet apply init.pp
+
+Using Hiera with additional coding standard:
+
+    classes:
+ 	- phpqatools
+        - git
+    phpqatools::standard_hash:
+        '/usr/share/pear/PHP/CodeSniffer/Standards/Symfony2':
+            ensure: latest
+            provider: git
+            source: 'git://github.com/opensky/Symfony2-coding-standard.git'
+            revision: 'master'
+	'/usr/share/pear/PHP/CodeSniffer/Standards/MyCompany':
+	    ensure: latest
+	    provider: git
+	    source: 'git://github.com/MyCompany/coding-standard.git'
+	    revision: 'master'
+    phpqatools::default_standard: Symfony2
 
 Known issues
 ------------

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then:
 Using Hiera with additional coding standard:
 
     classes:
- 	- phpqatools
+        - phpqatools
         - git
     phpqatools::standard_hash:
         '/usr/share/pear/PHP/CodeSniffer/Standards/Symfony2':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ class phpqatools (
 
 	# PHP_CodeSniffer
 	pear::package { "PHP_CodeSniffer":
-		version => "latest",
+		version => "1.4.6",
 		repository => "pear.php.net",
 		require => Pear::Package["PEAR"],
 	}
@@ -104,7 +104,7 @@ class phpqatools (
 
 	# Phing
 	pear::package { "Phing":
-		version => "latest",
+		version => "2.5.0",
 		repository => "pear.phing.info",
 		require => Pear::Package["PEAR"],
 	}
@@ -115,7 +115,7 @@ class phpqatools (
 	}
 
 	pear::package { "PhpDocumentor":
-		version => 'latest',
+		version => '1.4.4',
 		repository => "pear.php.net",
 	}
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,7 @@ class phpqatools (
 	# install additional coding standards
 	create_resources('vcsrepo', $standard_hash)
    
-	if defined($default_standard) {
+	if $default_standard != undef {
 	  exec {"phpcs --config-set default_standard ${default_standard}":
 		cwd => '/tmp',
 		path => ['/usr/bin'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,10 @@
 # Sample Usage:
 #
 # [Remember: No empty lines between comments and class definition]
-class phpqatools {
+class phpqatools (
+	$standard_hash = {},
+	$default_standard = undef,
+) {
 	include pear
 
 	# PEAR Package
@@ -111,4 +114,19 @@ class phpqatools {
 		repository => "pear.netpirates.net"
 	}
 
+	pear::package { "PhpDocumentor":
+		version => 'latest',
+		repository => "pear.php.net",
+	}
+
+	# install addtional codeing standards
+	create_resources('vcsrepo', $standard_hash)
+   
+	if defined($default_standard) {
+	  exec {"phpcs --config-set default_standard ${default_standard}":
+		cwd => '/tmp',
+		path => ['/usr/bin'],
+		creates => '/usr/share/pear/data/PHP_CodeSniffer/CodeSniffer.conf'
+	  }
+	}
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,7 +119,7 @@ class phpqatools (
 		repository => "pear.php.net",
 	}
 
-	# install addtional codeing standards
+	# install additional coding standards
 	create_resources('vcsrepo', $standard_hash)
    
 	if defined($default_standard) {


### PR DESCRIPTION
Also changed a few packages to use version instead of latest. It seems pear remote-info return the latest beta version and pear upgrade --force won't upgrade to that version. Puppet will generate active notifications on every run.
