### PR TITLE
Update version for PHP_Depend and Phing

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ class phpqatools (
 
 	# PHP_CodeSniffer
 	pear::package { "PHP_CodeSniffer":
-		version => "1.4.6",
+		version => "latest",
 		repository => "pear.php.net",
 		require => Pear::Package["PEAR"],
 	}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,7 @@ class phpqatools (
 
 	# Pdepend
 	pear::package { "PHP_Depend":
-		version => "beta",
+		version => "latest",
 		repository => "pear.pdepend.org",
 		require => Pear::Package["PEAR"],
 	}
@@ -103,8 +103,8 @@ class phpqatools (
 	}
 
 	# Phing
-	pear::package { "Phing":
-		version => "2.5.0",
+	pear::package { "phing":
+		version => "latest",
 		repository => "pear.phing.info",
 		require => Pear::Package["PEAR"],
 	}


### PR DESCRIPTION
Also correct the package name for Phing to phing, which is the name listed
on pear list -a. Otherwise, pear module will keep sending ensure notice.
